### PR TITLE
introduce workflow_dispatch event to depup

### DIFF
--- a/.github/workflows/depup.yml
+++ b/.github/workflows/depup.yml
@@ -4,6 +4,7 @@ on:
     - cron:  '14 14 * * *' # Runs at 14:14 UTC every day
   repository_dispatch:
     types: [depup]
+  workflow_dispatch:
 
 jobs:
   reviewdog:


### PR DESCRIPTION
GitHub Actions now supports manual triggers.
ref. https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/