### PR TITLE
SHELL ["/bin/ash", "-eo", "pipefail", "-c"] should be SHELL ["/bin/ba…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.12
 
 ENV REVIEWDOG_VERSION=v0.10.2
 
-SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
+SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
 
 # hadolint ignore=DL3006
 RUN apk --no-cache add git


### PR DESCRIPTION
…sh", "-eo", "pipefail", "-c"]

error here:
SHELL ["/bin/ash", "-eo", "pipefail", "-c"] 

should be:
SHELL ["/bin/bash", "-eo", "pipefail", "-c"]