### PR TITLE
:alien: Changes depup action url to new owner

### DIFF
--- a/.github/workflows/depup.yml
+++ b/.github/workflows/depup.yml
@@ -1,7 +1,7 @@
 name: depup
 on:
   schedule:
-    - cron:  '14 14 * * *' # Runs at 14:14 UTC every day
+    - cron: "14 14 * * *" # Runs at 14:14 UTC every day
   repository_dispatch:
     types: [depup]
   workflow_dispatch:
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: haya14busa/action-depup@v1
+      - uses: reviewdog/action-depup@v1
         id: depup
         with:
           file: Dockerfile

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Folders to ignore
+.vscode/

--- a/README.md
+++ b/README.md
@@ -108,8 +108,7 @@ Supported linters:
 - [reviewdog/action-misspell](https://github.com/reviewdog/action-misspell)
 
 ### Dependencies Update Automation
-This repository uses [haya14busa/action-depup](https://github.com/haya14busa/action-depup) to update
+This repository uses [reviewdog/action-depup](https://github.com/reviewdog/action-depup) to update
 reviewdog version.
 
 [![reviewdog depup demo](https://user-images.githubusercontent.com/3797062/73154254-170e7500-411a-11ea-8211-912e9de7c936.png)](https://github.com/reviewdog/action-template/pull/6)
-


### PR DESCRIPTION
The ownership of the depup action was changed to the reviewdogorganization (see https://github.com/reviewdog/action-depup/issues/22). This pull request changes the depup urls to reflect this change.