### PR TITLE
ci: remove '/refs/tags' prefix from release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
           # This token is provided by Actions, you do not need to create your own token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create "${TAG_NAME}" -t "Release ${TAG_NAME}" --notes "${BODY}"
+          gh release create "${TAG_NAME}" -t "Release ${TAG_NAME/refs\/tags\//}" --notes "${BODY}"
 
   release-check:
     if: github.event.action == 'labeled'


### PR DESCRIPTION
This PR removes the `/refs/tags` prefix from the release title if the action was triggered by tagging directly on the main branch.